### PR TITLE
feat: refactor actix-http responses (#1713)

### DIFF
--- a/src/common/meta/http.rs
+++ b/src/common/meta/http.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use actix_web::http::StatusCode;
+use actix_web::HttpResponse as ActixHttpResponse;
+
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
@@ -63,6 +66,21 @@ impl HttpResponse {
             message: err.get_message(),
             error_detail: Some(err.get_error_detail()),
         }
+    }
+
+    /// Send a bad request response in json format and associate the
+    /// provided error as `error` field.
+    pub fn bad_request(error: impl ToString) -> ActixHttpResponse {
+        ActixHttpResponse::BadRequest().json(Self::error(
+            StatusCode::BAD_REQUEST.into(),
+            error.to_string(),
+        ))
+    }
+
+    /// Send a response in json format, status code is 200.
+    /// The payload should be serde-serializable.
+    pub fn json(payload: impl Serialize) -> ActixHttpResponse {
+        ActixHttpResponse::Ok().json(payload)
     }
 }
 

--- a/src/handler/http/request/kv/mod.rs
+++ b/src/handler/http/request/kv/mod.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::common::meta::http::HttpResponse as MetaHttpResponse;
+use crate::service::kv;
 use actix_web::http::header::ContentType;
 use actix_web::{delete, get, post, web, HttpRequest, HttpResponse};
 use ahash::HashMap;
 use std::io::Error;
-
-use crate::service::kv;
 
 /** GetValue */
 #[utoipa::path(
@@ -141,11 +141,11 @@ pub async fn list(org_id: web::Path<String>, in_req: HttpRequest) -> Result<Http
         None => "",
     };
     match kv::list(&org_id, prefix).await {
-        Ok(keys) => Ok(HttpResponse::Ok().json(keys)),
+        Ok(keys) => Ok(MetaHttpResponse::json(keys)),
         Err(err) => {
             log::error!("list KV keys: {}, error: {}", prefix, err);
             let keys: Vec<String> = Vec::new();
-            Ok(HttpResponse::Ok().json(keys))
+            Ok(MetaHttpResponse::json(keys))
         }
     }
 }

--- a/src/handler/http/request/logs/ingest.rs
+++ b/src/handler/http/request/logs/ingest.rs
@@ -50,7 +50,7 @@ pub async fn bulk(
 ) -> Result<HttpResponse, Error> {
     let org_id = org_id.into_inner();
     Ok(match logs::bulk::ingest(&org_id, body, **thread_id).await {
-        Ok(v) => HttpResponse::Ok().json(v),
+        Ok(v) => MetaHttpResponse::json(v),
         Err(e) => {
             log::error!("Error processing request: {:?}", e);
             HttpResponse::BadRequest().json(MetaHttpResponse::error(
@@ -95,7 +95,7 @@ pub async fn multi(
         )
         .await
         {
-            Ok(v) => HttpResponse::Ok().json(v),
+            Ok(v) => MetaHttpResponse::json(v),
             Err(e) => {
                 log::error!("Error processing request: {:?}", e);
                 HttpResponse::BadRequest().json(MetaHttpResponse::error(
@@ -116,7 +116,7 @@ pub async fn multi_v1(
     let (org_id, stream_name) = path.into_inner();
     Ok(
         match logs::multi::ingest(&org_id, &stream_name, body, **thread_id).await {
-            Ok(v) => HttpResponse::Ok().json(v),
+            Ok(v) => MetaHttpResponse::json(v),
             Err(e) => {
                 log::error!("Error processing request: {:?}", e);
                 HttpResponse::BadRequest().json(MetaHttpResponse::error(
@@ -162,7 +162,7 @@ pub async fn json(
         )
         .await
         {
-            Ok(v) => HttpResponse::Ok().json(v),
+            Ok(v) => MetaHttpResponse::json(v),
             Err(e) => {
                 log::error!("Error processing request: {:?}", e);
                 HttpResponse::BadRequest().json(MetaHttpResponse::error(
@@ -183,7 +183,7 @@ pub async fn json_v1(
     let (org_id, stream_name) = path.into_inner();
     Ok(
         match logs::json::ingest(&org_id, &stream_name, body, **thread_id).await {
-            Ok(v) => HttpResponse::Ok().json(v),
+            Ok(v) => MetaHttpResponse::json(v),
             Err(e) => {
                 log::error!("Error processing request: {:?}", e);
                 HttpResponse::BadRequest().json(MetaHttpResponse::error(
@@ -234,7 +234,7 @@ pub async fn handle_kinesis_request(
                     log::error!("Error processing request: {:?}", v);
                     HttpResponse::BadRequest().json(v)
                 } else { */
-                HttpResponse::Ok().json(v)
+                MetaHttpResponse::json(v)
                 //}
             }
             Err(e) => {
@@ -269,7 +269,7 @@ pub async fn handle_kinesis_request_v1(
                     log::error!("Error processing request: {:?}", v);
                     HttpResponse::BadRequest().json(v)
                 } else {
-                    HttpResponse::Ok().json(v)
+                    MetaHttpResponse::json(v)
                 }
             }
             Err(e) => {
@@ -299,7 +299,7 @@ pub async fn handle_gcp_request_v1(
                     log::error!("Error processing request: {:?}", v);
                     HttpResponse::BadRequest().json(v)
                 } else {
-                    HttpResponse::Ok().json(v)
+                    MetaHttpResponse::json(v)
                 }
             }
             Err(e) => {
@@ -329,7 +329,7 @@ pub async fn handle_gcp_request(
         )
         .await
         {
-            Ok(v) => HttpResponse::Ok().json(v),
+            Ok(v) => MetaHttpResponse::json(v),
             Err(e) => {
                 log::error!("Error processing request: {:?}", e);
                 HttpResponse::BadRequest().json(MetaHttpResponse::error(

--- a/src/handler/http/request/rum/ingest.rs
+++ b/src/handler/http/request/rum/ingest.rs
@@ -16,7 +16,7 @@ use crate::common::meta::middleware_data::RumExtraData;
 use crate::common::{meta::http::HttpResponse as MetaHttpResponse, utils::json};
 use crate::service::logs;
 use actix_multipart::form::{bytes::Bytes, MultipartForm};
-use actix_web::{http, post, web, HttpResponse};
+use actix_web::{post, web, HttpResponse};
 use ahash::AHashMap;
 
 use std::io::Error;
@@ -172,7 +172,9 @@ pub async fn sessionreplay(
     if let Err(_e) =
         ZlibDecoder::new(&payload.segment.data[..]).read_to_string(&mut segment_payload)
     {
-        return Ok(bad_request("Failed to decompress the incoming payload"));
+        return Ok(MetaHttpResponse::bad_request(
+            "Failed to decompress the incoming payload",
+        ));
     }
 
     let event: Event = json::from_slice(&payload.event.data[..]).unwrap();
@@ -203,18 +205,8 @@ async fn ingest_multi_json(
     Ok(
         match logs::multi::ingest_with_keys(org_id, stream_name, body, extend_json, thread_id).await
         {
-            Ok(v) => HttpResponse::Ok().json(v),
-            Err(e) => bad_request(e.to_string()),
+            Ok(v) => MetaHttpResponse::json(v),
+            Err(e) => MetaHttpResponse::bad_request(e),
         },
     )
-}
-
-fn bad_request<T>(reason: T) -> HttpResponse
-where
-    T: Into<String>,
-{
-    HttpResponse::BadRequest().json(MetaHttpResponse::error(
-        http::StatusCode::BAD_REQUEST.into(),
-        reason.into(),
-    ))
 }

--- a/src/handler/http/request/search/mod.rs
+++ b/src/handler/http/request/search/mod.rs
@@ -107,16 +107,16 @@ pub async fn search(
     let query = web::Query::<AHashMap<String, String>>::from_query(in_req.query_string()).unwrap();
     let stream_type = match get_stream_type_from_request(&query) {
         Ok(v) => v.unwrap_or(StreamType::Logs),
-        Err(e) => return Ok(bad_request(e)),
+        Err(e) => return Ok(MetaHttpResponse::bad_request(e)),
     };
 
     // handle encoding for query and aggs
     let mut req: meta::search::Request = match json::from_slice(&body) {
         Ok(v) => v,
-        Err(e) => return Ok(bad_request(e)),
+        Err(e) => return Ok(MetaHttpResponse::bad_request(e)),
     };
     if let Err(e) = req.decode() {
-        return Ok(bad_request(e));
+        return Ok(MetaHttpResponse::bad_request(e));
     }
 
     let mut query_fn = req.query.query_fn.and_then(|v| base64::decode(&v).ok());
@@ -271,12 +271,12 @@ pub async fn around(
     let query = web::Query::<AHashMap<String, String>>::from_query(in_req.query_string()).unwrap();
     let stream_type = match get_stream_type_from_request(&query) {
         Ok(v) => v.unwrap_or(StreamType::Logs),
-        Err(e) => return Ok(bad_request(e)),
+        Err(e) => return Ok(MetaHttpResponse::bad_request(e)),
     };
 
     let around_key = match query.get("key") {
         Some(v) => v.parse::<i64>().unwrap_or(0),
-        None => return Ok(bad_request("around key is empty")),
+        None => return Ok(MetaHttpResponse::bad_request("around key is empty")),
     };
     let query_fn = query.get("query_fn").and_then(|v| base64::decode(v).ok());
 
@@ -524,12 +524,12 @@ pub async fn values(
     let query = web::Query::<AHashMap<String, String>>::from_query(in_req.query_string()).unwrap();
     let stream_type = match get_stream_type_from_request(&query) {
         Ok(v) => v.unwrap_or(StreamType::Logs),
-        Err(e) => return Ok(bad_request(e)),
+        Err(e) => return Ok(meta::http::HttpResponse::bad_request(e)),
     };
 
     let fields = match query.get("fields") {
         Some(v) => v.split(',').map(|s| s.to_string()).collect::<Vec<_>>(),
-        None => return Ok(bad_request("fields is empty")),
+        None => return Ok(MetaHttpResponse::bad_request("fields is empty")),
     };
     let mut query_fn = query.get("query_fn").and_then(|v| base64::decode(v).ok());
     if let Some(vrl_function) = &query_fn {
@@ -575,7 +575,7 @@ pub async fn values(
         .get("start_time")
         .map_or(0, |v| v.parse::<i64>().unwrap_or(0));
     if start_time == 0 {
-        return Ok(bad_request("start_time is empty"));
+        return Ok(MetaHttpResponse::bad_request("start_time is empty"));
     }
     let mut end_time = query
         .get("end_time")
@@ -708,11 +708,4 @@ pub async fn values(
     .await;
 
     Ok(HttpResponse::Ok().json(resp))
-}
-
-fn bad_request(error: impl ToString) -> HttpResponse {
-    HttpResponse::BadRequest().json(MetaHttpResponse::error(
-        StatusCode::BAD_REQUEST.into(),
-        error.to_string(),
-    ))
 }

--- a/src/handler/http/request/search/saved_view.rs
+++ b/src/handler/http/request/search/saved_view.rs
@@ -1,0 +1,6 @@
+/// POST: to save a view
+/// GET: 
+/// - List saved views
+/// - Get one view
+/// DELETE: saved views
+/// PUT: Edit views


### PR DESCRIPTION
Introduced two new methods in meta::http::HttpResponse struct
- json()
- bad_request()

Main motivation behind this is to unify the actix-response as we had no consistent way for sending out them, especially `bad_request()`